### PR TITLE
Enable lazy RCU by default

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -100,7 +100,9 @@ BOARD_BOOTCONFIG := \
     androidboot.usbcontroller=4e00000.dwc3
 
 BOARD_KERNEL_CMDLINE := \
-    video=vfb:640x400,bpp=32,memsize=3072000
+    video=vfb:640x400,bpp=32,memsize=3072000 \
+    rcu_nocbs=all \
+    rcutree.enable_rcu_lazy=1 \
 
 # Kernel prebuilt
 TARGET_KERNEL_ARCH := arm64

--- a/DeviceSettings/res/values-es/strings.xml
+++ b/DeviceSettings/res/values-es/strings.xml
@@ -21,10 +21,7 @@
     <string name="enable_high_refresh_rate_summary">Habilita una tasa de refresco alta para una experiencia más fluida</string>
     <string name="current_refresh_rate_info">Tasa de refresco máxima/mínima: <xliff:g id="version">%1$s</xliff:g>Hz - <xliff:g id="version">%2$s</xliff:g>Hz</string>
 
-    <string name="display_title">Pantalla</string>
-    <string name="dc_dimming_title">Atenuación de CC</string>
-    <string name="dc_dimming_summary">Habilita la atenuación de CC para evitar parpadeo en condiciones de brillo bajo</string>
-
+    <!-- Sound -->
     <string name="sound_title">Sonido</string>
 
     <string name="dirac_enable">Habilitar el potenciador de sonido</string>

--- a/DeviceSettings/res/values/strings.xml
+++ b/DeviceSettings/res/values/strings.xml
@@ -23,10 +23,7 @@
     <!-- Refresh Rate tile -->
     <string name="refresh_rate_tile_title">Refresh Rate</string>
 
-    <string name="display_title">Display</string>
-    <string name="dc_dimming_title">DC Dimming</string>
-    <string name="dc_dimming_summary">Enable DC Dimming to avoid screen flickering on low brightness levels</string>
-
+    <!-- Sound -->
     <string name="sound_title">Sound</string>
 
     <string name="dirac_enable">Enable sound enhancement</string>

--- a/DeviceSettings/res/xml/main_settings.xml
+++ b/DeviceSettings/res/xml/main_settings.xml
@@ -34,18 +34,6 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="display_category"
-        android:title="@string/display_title">
-
-        <SwitchPreference
-            android:key="pref_dc_dimming"
-            android:title="@string/dc_dimming_title"
-            android:summary="@string/dc_dimming_summary"
-            android:icon="@drawable/ic_dc_dimming"/>
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
         android:key="sound_category"
         android:title="@string/sound_title">
 

--- a/DeviceSettings/src/org/lineageos/settings/device/BootCompletedReceiver.java
+++ b/DeviceSettings/src/org/lineageos/settings/device/BootCompletedReceiver.java
@@ -37,7 +37,6 @@ public class BootCompletedReceiver extends BroadcastReceiver {
     public void onReceive(final Context context, Intent intent) {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 
-        DisplayUtils.setDcDimmingStatus(sharedPreferences.getBoolean(Constants.KEY_DC_DIMMING, false));
         DisplayUtils.updateRefreshRateSettings(context);
         DiracUtils.initialize(context);
     }

--- a/DeviceSettings/src/org/lineageos/settings/device/MainSettingsFragment.java
+++ b/DeviceSettings/src/org/lineageos/settings/device/MainSettingsFragment.java
@@ -33,7 +33,6 @@ public class MainSettingsFragment extends PreferenceFragment {
 
     private Preference mPrefRefreshRateInfo;
     private ListPreference mPrefRefreshRateConfig;
-    private SwitchPreference mPrefDcDimming;
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
@@ -47,8 +46,6 @@ public class MainSettingsFragment extends PreferenceFragment {
         mPrefRefreshRateConfig = (ListPreference) findPreference(Constants.KEY_REFRESH_RATE_CONFIG);
         mPrefRefreshRateConfig.setOnPreferenceChangeListener(PrefListener);
         mPrefRefreshRateInfo = (Preference) findPreference(Constants.KEY_REFRESH_RATE_INFO);
-        mPrefDcDimming = (SwitchPreference) findPreference(Constants.KEY_DC_DIMMING);
-        mPrefDcDimming.setOnPreferenceChangeListener(PrefListener);
         updateSummary();
     }
 
@@ -60,8 +57,6 @@ public class MainSettingsFragment extends PreferenceFragment {
 
                 if (Constants.KEY_REFRESH_RATE_CONFIG.equals(key)) {
                     setHzConfig();
-                } else if (Constants.KEY_DC_DIMMING.equals(key)) {
-                    DisplayUtils.setDcDimmingStatus((boolean) value);
                 }
 
                 return true;

--- a/DeviceSettings/src/org/lineageos/settings/device/utils/DisplayUtils.java
+++ b/DeviceSettings/src/org/lineageos/settings/device/utils/DisplayUtils.java
@@ -12,12 +12,6 @@ import org.lineageos.settings.device.Constants;
 import org.lineageos.settings.device.utils.FileUtils;
 
 public class DisplayUtils {
-    public static void setDcDimmingStatus(boolean enabled) {
-        FileUtils.writeLine(Constants.DISPPARAM_NODE, enabled ? Constants.DISPPARAM_DC_ON : Constants.DISPPARAM_DC_OFF);
-
-        // Update the brightness node so dc dimming updates its state
-        FileUtils.writeLine(Constants.BRIGHTNESS_NODE, FileUtils.readOneLine(Constants.BRIGHTNESS_NODE));
-    }
 
     public static void updateRefreshRateSettings(final Context context) {
         Handler.getMain().post(() -> {

--- a/extract-files.sh
+++ b/extract-files.sh
@@ -61,6 +61,9 @@ function blob_fixup() {
         vendor/bin/hw/android.hardware.security.keymint-service-qti)
             grep -q "android.hardware.security.rkp-V3-ndk.so" "${2}" || ${PATCHELF} --add-needed "android.hardware.security.rkp-V3-ndk.so" "${2}"
             ;;
+        vendor/etc/init/hw/init.mi_thermald.rc|vendor/etc/init/hw/init.qcom.usb.rc|vendor/etc/init/vendor.qti.hardware.charger_monitor\@1.0-service.rc|vendor/etc/init/init.batterysecret.rc|vendor/etc/init/init.charge_logger.rc)
+            sed -i 's/on charger/on property:init.svc.vendor.charger=running/g' "${2}"
+            ;;
     esac
 }
 

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -186,7 +186,7 @@ vendor/lib64/soundfx/libvolumelistener.so
 # Battery
 vendor/bin/battery_stats
 vendor/bin/batterysecret
-vendor/etc/init/init.batterysecret.rc:|196eaa33df2da9f35f1c1d799663dcab12e73279
+vendor/etc/init/init.batterysecret.rc
 vendor/etc/init/vendor.qti.battery_stats.rc
 
 # Bluetooth
@@ -538,8 +538,8 @@ vendor/lib64/vendor.qti.hardware.cacert@1.0.so
 vendor/bin/charge_logger
 vendor/bin/hvdcp_opti
 vendor/bin/init.qti.chg_policy.sh
-vendor/etc/init/init.charge_logger.rc|97cb51da3967d5844b69de338507ff950c291504
-vendor/etc/init/vendor.qti.hardware.charger_monitor@1.0-service.rc|674434781851bcb0baa3bcb110fee5417b81053e
+vendor/etc/init/init.charge_logger.rc
+vendor/etc/init/vendor.qti.hardware.charger_monitor@1.0-service.rc
 vendor/etc/charger_fstab.qti
 
 # CNE
@@ -1725,7 +1725,7 @@ vendor/lib64/libsubsystem_control.so
 # Thermal
 vendor/bin/mi_thermald
 vendor/bin/thermal-engine-v2
-vendor/etc/init/init.mi_thermald.rc|7e0e15cf3915ed0a0ec4e2f1900ec7f5d28f3b0b
+vendor/etc/init/init.mi_thermald.rc
 vendor/etc/init/init_thermal-engine-v2.rc
 vendor/etc/thermal-camera.conf
 vendor/etc/thermal-chg-only.conf
@@ -1776,7 +1776,7 @@ vendor/lib64/vendor.qti.hardware.tui_comm@1.0.so
 vendor/bin/hw/android.hardware.usb@1.2-service-qti
 vendor/bin/init.qcom.usb.sh
 vendor/etc/init/android.hardware.usb@1.2-service-qti.rc
-vendor/etc/init/hw/init.qcom.usb.rc|0586fa67b6e6377742baf1fb270e880b7bd90110
+vendor/etc/init/hw/init.qcom.usb.rc
 vendor/etc/usb_compositions.conf
 vendor/etc/vintf/manifest/android.hardware.usb@1.2-service.xml
 


### PR DESCRIPTION
Lazy RCU optimizes the RCU callbacks for power efficiency by delaying them on idle systems, and batching them for reduced CPU wakeups.

This improves battery life on phones and other power-sensitive devices.

[ACK 5.15.148 has backported lazy RCU, and introduced a boot parameter to control this feature](https://android.googlesource.com/kernel/common/+/b657edec328aa29f0ee3f6f7dda328ff3a2cb6b1) - It is however disabled by default.

So, let's enable Lazy RCU by default using the `rcutree.enable_rcu_lazy` & `rcu_nocbs` `BOARD_KERNEL_CMDLINE` parameters